### PR TITLE
Added option to obfuscate device IDs in the console/log view

### DIFF
--- a/src/SyncTrayzor/Pages/ConsoleViewModel.cs
+++ b/src/SyncTrayzor/Pages/ConsoleViewModel.cs
@@ -16,6 +16,7 @@ namespace SyncTrayzor.Pages
         private const int maxLogMessages = 1500;
 
         private readonly ISyncThingManager syncThingManager;
+        private readonly IConfigurationProvider configurationProvider;
 
         public ObservableQueue<string> LogMessages { get; private set; }
 
@@ -24,10 +25,16 @@ namespace SyncTrayzor.Pages
             IConfigurationProvider configurationProvider
             )
         {
+            this.syncThingManager = syncThingManager;
+            this.configurationProvider = configurationProvider;
+            this.LogMessages = new ObservableQueue<string>();
+
             var configuration = configurationProvider.Load();
 
-            this.syncThingManager = syncThingManager;
-            this.LogMessages = new ObservableQueue<string>();
+            configurationProvider.ConfigurationChanged += (o, e) =>
+            {
+                configuration = configurationProvider.Load();
+            };
 
             this.syncThingManager.MessageLogged += (o, e) =>
             {

--- a/src/SyncTrayzor/Pages/ConsoleViewModel.cs
+++ b/src/SyncTrayzor/Pages/ConsoleViewModel.cs
@@ -1,11 +1,13 @@
-﻿using Stylet;
+using Stylet;
 using SyncTrayzor.SyncThing;
 using SyncTrayzor.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using SyncTrayzor.Services;
 
 namespace SyncTrayzor.Pages
 {
@@ -17,14 +19,28 @@ namespace SyncTrayzor.Pages
 
         public ObservableQueue<string> LogMessages { get; private set; }
 
-        public ConsoleViewModel(ISyncThingManager syncThingManager)
+        public ConsoleViewModel(
+            ISyncThingManager syncThingManager,
+            IConfigurationProvider configurationProvider
+            )
         {
+            var configuration = configurationProvider.Load();
+
             this.syncThingManager = syncThingManager;
             this.LogMessages = new ObservableQueue<string>();
 
             this.syncThingManager.MessageLogged += (o, e) =>
             {
-                this.LogMessages.Enqueue(e.LogMessage);
+                var message = e.LogMessage;
+
+                // Check if device IDs need to be obfuscated
+                if (configuration.ObfuscateDeviceIDs)
+                {
+                    var rgx = new Regex(@"-[0-9A-Z]{7}-[0-9A-Z]{7}-[0-9A-Z]{7}-[0-9A-Z]{7}-[0-9A-Z]{7}-[0-9A-Z]{7}-[0-9A-Z]{7}");
+                    message = rgx.Replace(message, "");
+                }
+
+                this.LogMessages.Enqueue(message);
                 if (this.LogMessages.Count > maxLogMessages)
                     this.LogMessages.Dequeue();
             };

--- a/src/SyncTrayzor/Pages/SettingsView.xaml
+++ b/src/SyncTrayzor/Pages/SettingsView.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="SyncTrayzor.Pages.SettingsView"
+<Window x:Class="SyncTrayzor.Pages.SettingsView"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:s="https://github.com/canton7/Stylet"
@@ -7,7 +7,7 @@
         xmlns:pages="clr-namespace:SyncTrayzor.Pages"
         mc:Ignorable="d" 
         d:DataContext="{d:DesignInstance pages:SettingsViewModel}"
-        Height="600" Width="400"
+        Height="675.903" Width="400"
         Title="Settings"
         ResizeMode="NoResize" SizeToContent="Height">
     <Window.Resources>
@@ -18,19 +18,20 @@
             <Style TargetType="GroupBox">
                 <Setter Property="Padding" Value="5"/>
                 <Setter Property="Margin" Value="0,5,0,5"/>
-            </Style>    
+            </Style>
         </DockPanel.Resources>
-        
-        <GroupBox DockPanel.Dock="Top" Header="SyncTrayzor">
+
+        <GroupBox DockPanel.Dock="Top" Header="SyncTrayzor" Height="126">
             <DockPanel>
                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding MinimizeToTray}">Minimize to tray</CheckBox>
                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding CloseToTray}">Close to tray</CheckBox>
                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding ShowTrayIconOnlyOnClose}">Show Tray Icon only on close</CheckBox>
                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding ShowSynchronizedBalloon}">Show 'Synchronized' balloon messages</CheckBox>
                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding NotifyOfNewVersions}">Alert if a new version of SyncTrayzor is available</CheckBox>
+                <CheckBox DockPanel.Dock="Top" IsChecked="{Binding ObfuscateDeviceIDs}">Obfuscate device IDs in the log view</CheckBox>
             </DockPanel>
         </GroupBox>
-        
+
         <GroupBox DockPanel.Dock="Top" Header="Syncthing">
             <DockPanel>
                 <DockPanel.Resources>
@@ -43,7 +44,7 @@
                         you can set it to whatever value you like here.
                     </ToolTip>
                 </DockPanel.Resources>
-                
+
                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding StartSyncThingAutomatically}">Start Syncthing when SyncTrayzor starts</CheckBox>
 
                 <Label DockPanel.Dock="Top" Target="{Binding ElementName=SyncThingAddress}" ToolTip="{StaticResource AddressOverride}">GUI Listen Address:</Label>
@@ -51,11 +52,11 @@
 
                 <Label DockPanel.Dock="Top" Target="{Binding ElementName=SyncThingApiKey}" ToolTip="{StaticResource APIKeyOverride}">API Key:</Label>
                 <TextBox DockPanel.Dock="Top" x:Name="SyncThingApiKey" Text="{Binding SyncThingApiKey}"  ToolTip="{StaticResource APIKeyOverride}"/>
-                
+
                 <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="0,5,0,0">You must restart Syncthing for changes in these settings to take effect</TextBlock>
             </DockPanel>
         </GroupBox>
-        
+
         <GroupBox DockPanel.Dock="Top" Header="Start on Login">
             <DockPanel>
                 <TextBlock DockPanel.Dock="Top" Visibility="{Binding CanReadAndWriteAutostart, Converter={StaticResource InverseVisibilityConverter}}"
@@ -64,7 +65,7 @@
                 </TextBlock>
                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding StartOnLogon}"
                           IsEnabled="{Binding CanWriteAutostart}" Visibility="{Binding CanReadOrWriteAutostart, Converter={x:Static s:BoolToVisibilityConverter.Instance}}">
-                          Automatically start on login
+                    Automatically start on login
                 </CheckBox>
                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding StartMinimized}"
                           IsEnabled="{Binding StartMinimizedEnabled}" Visibility="{Binding CanReadOrWriteAutostart, Converter={x:Static s:BoolToVisibilityConverter.Instance}}">
@@ -90,7 +91,7 @@
                 </ItemsControl>
             </DockPanel>
         </GroupBox>
-        
+
         <Expander DockPanel.Dock="Top" Header="Advanced">
             <GroupBox>
                 <DockPanel>
@@ -108,8 +109,8 @@
                 </DockPanel>
             </GroupBox>
         </Expander>
-        
-        <StackPanel DockPanel.Dock="Bottom" Margin="0,10,0,0" Orientation="Horizontal" HorizontalAlignment="Right">
+
+        <StackPanel DockPanel.Dock="Bottom" Margin="0,10,0,0" Orientation="Horizontal" Height="37" HorizontalAlignment="Right" Width="204" VerticalAlignment="Bottom">
             <Button IsCancel="True" Command="{s:Action Cancel}">Cancel</Button>
             <Button IsDefault="True" Command="{s:Action Save}">Save</Button>
         </StackPanel>

--- a/src/SyncTrayzor/Pages/SettingsView.xaml
+++ b/src/SyncTrayzor/Pages/SettingsView.xaml
@@ -21,7 +21,7 @@
             </Style>
         </DockPanel.Resources>
 
-        <GroupBox DockPanel.Dock="Top" Header="SyncTrayzor" Height="126">
+        <GroupBox DockPanel.Dock="Top" Header="SyncTrayzor">
             <DockPanel>
                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding MinimizeToTray}">Minimize to tray</CheckBox>
                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding CloseToTray}">Close to tray</CheckBox>
@@ -110,7 +110,7 @@
             </GroupBox>
         </Expander>
 
-        <StackPanel DockPanel.Dock="Bottom" Margin="0,10,0,0" Orientation="Horizontal" Height="37" HorizontalAlignment="Right" Width="204" VerticalAlignment="Bottom">
+        <StackPanel DockPanel.Dock="Bottom" Margin="0,10,0,0" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom">
             <Button IsCancel="True" Command="{s:Action Cancel}">Cancel</Button>
             <Button IsDefault="True" Command="{s:Action Save}">Save</Button>
         </StackPanel>

--- a/src/SyncTrayzor/Pages/SettingsViewModel.cs
+++ b/src/SyncTrayzor/Pages/SettingsViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Stylet;
+using Stylet;
 using SyncTrayzor.Services;
 using SyncTrayzor.SyncThing;
 using System;
@@ -25,6 +25,7 @@ namespace SyncTrayzor.Pages
         public bool CloseToTray { get; set; }
         public bool ShowSynchronizedBalloon { get; set; }
         public bool NotifyOfNewVersions { get; set; }
+        public bool ObfuscateDeviceIDs { get; set; }
 
         public bool StartSyncThingAutomatically { get; set; }
         public string SyncThingAddress { get; set; }
@@ -64,6 +65,8 @@ namespace SyncTrayzor.Pages
             this.CloseToTray = configuration.CloseToTray;
             this.ShowSynchronizedBalloon = configuration.ShowSynchronizedBalloon;
             this.NotifyOfNewVersions = configuration.NotifyOfNewVersions;
+            this.ObfuscateDeviceIDs = configuration.ObfuscateDeviceIDs;
+
             this.StartSyncThingAutomatically = configuration.StartSyncthingAutomatically;
             this.SyncThingAddress = configuration.SyncthingAddress;
             this.SyncThingApiKey = configuration.SyncthingApiKey;
@@ -95,6 +98,8 @@ namespace SyncTrayzor.Pages
             configuration.CloseToTray = this.CloseToTray;
             configuration.ShowSynchronizedBalloon = this.ShowSynchronizedBalloon;
             configuration.NotifyOfNewVersions = this.NotifyOfNewVersions;
+            configuration.ObfuscateDeviceIDs = this.ObfuscateDeviceIDs;
+
             configuration.StartSyncthingAutomatically = this.StartSyncThingAutomatically;
             configuration.SyncthingAddress = this.SyncThingAddress;
             configuration.SyncthingApiKey = this.SyncThingApiKey;

--- a/src/SyncTrayzor/Services/Configuration.cs
+++ b/src/SyncTrayzor/Services/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -50,6 +50,7 @@ namespace SyncTrayzor.Services
         [XmlArrayItem("Folder")]
         public List<FolderConfiguration> Folders { get; set; }
         public bool NotifyOfNewVersions { get; set; }
+        public bool ObfuscateDeviceIDs { get; set; }
 
         [XmlIgnore]
         public Version LatestNotifiedVersion { get; set; }
@@ -77,6 +78,7 @@ namespace SyncTrayzor.Services
             this.SyncthingUseCustomHome = isPortableMode;
             this.Folders = new List<FolderConfiguration>();
             this.NotifyOfNewVersions = true;
+            this.ObfuscateDeviceIDs = false;
             this.LatestNotifiedVersion = null;
         }
 
@@ -93,6 +95,7 @@ namespace SyncTrayzor.Services
             this.SyncthingUseCustomHome = other.SyncthingUseCustomHome;
             this.Folders = other.Folders.Select(x => new FolderConfiguration(x)).ToList();
             this.NotifyOfNewVersions = other.NotifyOfNewVersions;
+            this.ObfuscateDeviceIDs = other.ObfuscateDeviceIDs;
             this.LatestNotifiedVersion = other.LatestNotifiedVersion;
         }
 
@@ -100,10 +103,10 @@ namespace SyncTrayzor.Services
         {
             return String.Format("<Configuration ShowTrayIconOnlyOnClose={0} MinimizeToTray={1} CloseToTray={2} ShowSynchronizedBalloon={3} " +
                 "SyncthingAddress={4} StartSyncthingAutomatically={5} SyncthingApiKey={6} SyncthingTraceFacilities={7} " +
-                "SyncthingUseCustomHome={8} Folders=[{9}] NotifyOfNewVersions={10} LastNotifiedVersion={11}>",
+                "SyncthingUseCustomHome={8} Folders=[{9}] NotifyOfNewVersions={10} LastNotifiedVersion={11} ObfuscateDeviceIDs={12}>",
                 this.ShowTrayIconOnlyOnClose, this.MinimizeToTray, this.CloseToTray, this.ShowSynchronizedBalloon, this.SyncthingAddress,
                 this.StartSyncthingAutomatically, this.SyncthingApiKey, this.SyncthingTraceFacilities, this.SyncthingUseCustomHome,
-                String.Join(", ", this.Folders), this.NotifyOfNewVersions, this.LatestNotifiedVersion);
+                String.Join(", ", this.Folders), this.NotifyOfNewVersions, this.LatestNotifiedVersion, this.ObfuscateDeviceIDs);
         }
     }
 }


### PR DESCRIPTION
As the console view is now always coupled with the web view, I added a new option in the SyncTrayzor settings that allows to filter the full device IDs out of the console view. Helpfull if you demonstrate something over a stream/remote and don't want them to show up on a recording.