### PR TITLE
Syncthing translations not working

### DIFF
--- a/src/SyncTrayzor/Pages/ViewerViewModel.cs
+++ b/src/SyncTrayzor/Pages/ViewerViewModel.cs
@@ -1,10 +1,11 @@
-﻿using Stylet;
+using Stylet;
 using SyncTrayzor.SyncThing;
 using SyncTrayzor.Xaml;
 using SyncTrayzor.Utils;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -100,6 +101,7 @@ namespace SyncTrayzor.Pages
             // and https://github.com/cefsharp/CefSharp/issues/534#issuecomment-60694502
             var headers = request.Headers;
             headers["X-API-Key"] += this.syncThingManager.ApiKey;
+            headers["Accept-Language"] = CultureInfo.CurrentCulture.Name + @";q=0.8," + CultureInfo.CurrentUICulture.Name + @";q=0.6,en;q=0.4";
             request.Headers = headers;
 
             return false;


### PR DESCRIPTION
The chromium instance does not pass the correct accept-language header to show the translated syncthing UI.