### PR TITLE
Fix crash when renaming long path

### DIFF
--- a/src/SyncTrayzor/Services/DirectoryWatcher.cs
+++ b/src/SyncTrayzor/Services/DirectoryWatcher.cs
@@ -95,7 +95,7 @@ namespace SyncTrayzor.Services
                 watcher.Changed += OnChanged;
                 watcher.Created += OnChanged;
                 watcher.Deleted += OnChanged;
-                watcher.Renamed += OnRenamed;
+                watcher.Renamed += OnChanged;
 
                 watcher.EnableRaisingEvents = true;
 
@@ -113,12 +113,6 @@ namespace SyncTrayzor.Services
         private void OnChanged(object source, FileSystemEventArgs e)
         {
             this.PathChanged(e.FullPath);
-        }
-
-        private void OnRenamed(object source, RenamedEventArgs e)
-        {
-            this.PathChanged(e.FullPath);
-            this.PathChanged(e.OldFullPath);
         }
 
         private void PathChanged(string path)

--- a/src/SyncTrayzor/SyncTrayzor.csproj
+++ b/src/SyncTrayzor/SyncTrayzor.csproj
@@ -94,9 +94,9 @@
     <Reference Include="Refit">
       <HintPath>..\packages\refit.2.2.0\lib\Net45\Refit.dll</HintPath>
     </Reference>
-    <Reference Include="Stylet, Version=1.1.4.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Stylet, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Stylet.1.1.4\lib\net45\Stylet.dll</HintPath>
+      <HintPath>..\packages\Stylet.1.1.5\lib\net45\Stylet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
This fixes a crash when renaming a file in a folder with path length > ~255 characters.
See also #72.

RenamedEventArgs.OldFullPath throws a System.IO.PathTooLongException on accessing, when it's an extended-length path.
In the same situation, RenamedEventArgs.FullPath is auto resolved to the matching short path, so I think this is maybe a bug in .Net...

But: As renaming only happens in the same folder, we don't need to notify Syncthing additionally about the change in the "old" folder, because old == new.