### PR TITLE
ProcessRunner: Fix --help option behavior

### DIFF
--- a/src/ProcessRunner/Program.cs
+++ b/src/ProcessRunner/Program.cs
@@ -26,14 +26,14 @@ namespace ProcessRunner
                 .Add("nowindow", "Set CreateNoWindow = true", v => noWindow = true);
 
             var pivotIndex = Array.IndexOf(args, "--");
-            if (pivotIndex < 0)
+            if (pivotIndex < 0 && Array.IndexOf(args, "-h") < 0 && Array.IndexOf(args, "--help") < 0)
             {
                 Console.Error.WriteLine("Must specify a command to run, see --help");
                 return 1;
             }
 
             var remainder = args.Skip(pivotIndex + 1).ToList();
-            var unknownArgs = options.Parse(args.Take(pivotIndex));
+            var unknownArgs = options.Parse(pivotIndex < 0 ? args : args.Take(pivotIndex));
 
             if (unknownArgs.Count > 0)
             {


### PR DESCRIPTION
now displays help, even when there is no pivot ("--") on the command line, as it should.

Improves user-friendliness of the tool.


Reason for this change:

Currently, the message when running without any options says "Must specify a command to run, see --help", but executing "ProcessRunner.exe --help" brings the same message.