### PR TITLE
Improve documentation for Syncthing default configuration folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Good question. The answer depends on whether you installed SyncTrayzor using the
 
 SyncTrayzor will install itself into `C:\Program Files\SyncTrayzor`. 
 
-By default, SyncTrayzor will put its own configuration in `C:\Users\<You>\AppData\Roaming\SyncTrayor`, and let Syncthing use [its default folder](https://docs.syncthing.net/users/config.html) for its database, which is `%AppData%/Syncthing` (Windows XP) or `%LocalAppData%/Syncthing` (Windows 7+).
+By default, SyncTrayzor will put its own configuration in `C:\Users\<You>\AppData\Roaming\SyncTrayor`, and let Syncthing use [the default Syncthing configuration folder](https://docs.syncthing.net/users/config.html) for its database, which is `%AppData%/Syncthing` (Windows XP) or `%LocalAppData%/Syncthing` (Windows 7+).
 It will also create a registry key at `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run\SyncTrayzor` the first time that it is run, which will let it start when you log in.
 
 You can delete this registry key by unchecking "Automatically start on login" in the settings.
@@ -148,7 +148,7 @@ This location is periodically cleared out (once every few days).
 
 SyncTrayzor will put its own configuration in `SyncTrayzorPortable\data`, and tell Syncthing to use `SyncTrayzorPortable\data\syncthing` for its database.
 This means that, when manually upgrading, you can simply move the 'data' folder over to move all your settings, and database.
-If you check "Use Syncthing's default database location" in the settings (on the Syncthing tab), then Syncthing will use its [its default folder](https://docs.syncthing.net/users/config.html) for its database, which is `%AppData%/Syncthing` (Windows XP) or `%LocalAppData%/Syncthing` (Windows 7+).
+If you check "Use Syncthing's default database location" in the settings (on the Syncthing tab), then Syncthing will use its [the default Syncthing configuration folder](https://docs.syncthing.net/users/config.html) for its database, which is `%AppData%/Syncthing` (Windows XP) or `%LocalAppData%/Syncthing` (Windows 7+).
 
 If you're moving from "raw" Syncthing to SyncTrayzor, you'll either want to check this setting or move/copy the contents of the default Syncthing folder into `data\syncthing`.
 

--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ Good question. The answer depends on whether you installed SyncTrayzor using the
 
 SyncTrayzor will install itself into `C:\Program Files\SyncTrayzor`. 
 
-By default, SyncTrayzor will put its own configuration in `C:\Users\<You>\AppData\Roaming\SyncTrayor`, and let Syncthing use its default folder for its database, which is `C:\Users\<You>\AppData\Roaming\Syncthing`.
+By default, SyncTrayzor will put its own configuration in `C:\Users\<You>\AppData\Roaming\SyncTrayor`, and let Syncthing use [its default folder](https://docs.syncthing.net/users/config.html) for its database, which is `%AppData%/Syncthing` (Windows XP) or `%LocalAppData%/Syncthing` (Windows 7+).
 It will also create a registry key at `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run\SyncTrayzor` the first time that it is run, which will let it start when you log in.
 
 You can delete this registry key by unchecking "Automatically start on login" in the settings.
 
-If you uncheck "Use Syncthing's default database location" in the settings, then SyncTrayzor will tell Syncthing to use `C:\Users\<You>\AppData\Roaming\SyncTrayzor\syncthing` for its database.
+If you uncheck "Use Syncthing's default database location" in the settings, then SyncTrayzor will tell Syncthing to use the default Syncthing folder for its database.
 This is useful if you want to keep the copy of Syncthing managed by SyncTrayzor separate from another copy running on your machine.
 
 The auto-update mechanism may download updates to `%TEMP%\SyncTrayzor`.
@@ -148,9 +148,9 @@ This location is periodically cleared out (once every few days).
 
 SyncTrayzor will put its own configuration in `SyncTrayzorPortable\data`, and tell Syncthing to use `SyncTrayzorPortable\data\syncthing` for its database.
 This means that, when manually upgrading, you can simply move the 'data' folder over to move all your settings, and database.
-If you check "Use Syncthing's default database location" in the settings (on the Syncthing tab), then Syncthing will use its default folder for its database, which is `C:\Users\<You>\AppData\Roaming\Syncthing`.
+If you check "Use Syncthing's default database location" in the settings (on the Syncthing tab), then Syncthing will use its [its default folder](https://docs.syncthing.net/users/config.html) for its database, which is `%AppData%/Syncthing` (Windows XP) or `%LocalAppData%/Syncthing` (Windows 7+).
 
-If you're moving from "raw" Syncthing to SyncTrayzor, you'll either want to check this setting or move/copy the contents of `C:\Users\<You>\AppData\Roaming\Syncthing` into `data\syncthing`.
+If you're moving from "raw" Syncthing to SyncTrayzor, you'll either want to check this setting or move/copy the contents of the default Syncthing folder into `data\syncthing`.
 
 The portable version won't start on login by default. If you check "Automatically start on login" in the settings, then a registry key will be created at `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run\SyncTrayzor`.
 


### PR DESCRIPTION
I improved the documentation a bit to correctly display the default Syncthing configuration folder. For me, `%LocalAppData%/Syncthing` maps to `C:\Users\<username>\AppData\Local\Syncthing` and not to `C:\Users\<username>\AppData\Roaming\Syncthing`.

If you like I can completely rewrite the section, as the subsections `Installed` and `Portable` now contain a lot of double lines.