### PR TITLE
Several minor UI/UX improvements

### DIFF
--- a/src/SyncTrayzor/NotifyIcon/TaskbarIconResources.xaml
+++ b/src/SyncTrayzor/NotifyIcon/TaskbarIconResources.xaml
@@ -93,9 +93,12 @@
                 <!-- TaskbarIcon starts by setting the DataContext to itself, so just ignore this... -->
                 <MenuItem Header="{l:Loc TrayIcon_Menu_Restore}" FontWeight="Bold"  Command="{s:Action Restore, ActionNotFound=Disable}"
                           Visibility="{Binding MainWindowVisible, Converter={StaticResource RestoreVisibility}}"/>
+                <Separator Visibility="{Binding MainWindowVisible, Converter={StaticResource RestoreVisibility}}"/>
+                
                 <MenuItem Header="{l:Loc TrayIcon_Menu_CloseToTray}" Command="{s:Action Minimize, ActionNotFound=Disable}"
                           Visibility="{Binding MainWindowVisible, Converter={x:Static s:BoolToVisibilityConverter.Instance}}"/>
-
+                <Separator Visibility="{Binding MainWindowVisible, Converter={x:Static s:BoolToVisibilityConverter.Instance}}"/>
+                
                 <MenuItem Header="{l:Loc TrayIcon_Menu_OpenFolder}" ItemsSource="{Binding Folders}"
                           Visibility="{Binding Folders, Converter={x:Static s:BoolToVisibilityConverter.Instance}}">
                     <MenuItem.ItemContainerStyle>
@@ -105,12 +108,16 @@
                         </Style>
                     </MenuItem.ItemContainerStyle>
                 </MenuItem>
+                <Separator Visibility="{Binding Folders, Converter={x:Static s:BoolToVisibilityConverter.Instance}}"/>
                 
                 <MenuItem Header="{l:Loc TrayIcon_Menu_StartSyncthing}" Command="{s:Action Start, ActionNotFound=Disable}"/>
                 <MenuItem Header="{l:Loc TrayIcon_Menu_StopSyncthing}" Command="{s:Action Stop, ActionNotFound=Disable}"/>
                 <MenuItem Header="{l:Loc TrayIcon_Menu_RestartSyncthing}" Command="{s:Action Restart, ActionNotFound=Disable}"/>
+                <Separator/>
 
                 <MenuItem Header="{l:Loc TrayIcon_Menu_Settings}" Command="{s:Action ShowSettings, ActionNotFound=Disable}"/>
+                <Separator/>
+                
                 <MenuItem Header="{l:Loc TrayIcon_Menu_Exit}" Command="{s:Action Exit, ActionNotFound=Disable}"/>
             </ContextMenu>
         </tb:TaskbarIcon.ContextMenu>

--- a/src/SyncTrayzor/NotifyIcon/TaskbarIconResources.xaml
+++ b/src/SyncTrayzor/NotifyIcon/TaskbarIconResources.xaml
@@ -18,7 +18,8 @@
     <tb:TaskbarIcon x:Key="TaskbarIcon" x:Name="TaskbarIcon"
                     Visibility="{Binding Visible, Converter={x:Static s:BoolToVisibilityConverter.Instance}}"
                     DoubleClickCommand="{s:Action DoubleClick, ActionNotFound=Disable}"
-                    MenuActivation="RightClick">
+                    MenuActivation="RightClick"
+                    ToolTipText="SyncTrayzor">
         <tb:TaskbarIcon.TrayPopup>
             <Popup StaysOpen="False" Placement="Relative" HorizontalOffset="-150" VerticalOffset="100" Width="300" PlacementTarget="{Binding ElementName=TaskbarIcon}" AllowsTransparency="True">
                 <i:Interaction.Behaviors>

--- a/src/SyncTrayzor/Pages/AboutView.xaml
+++ b/src/SyncTrayzor/Pages/AboutView.xaml
@@ -6,7 +6,7 @@
         Height="400" Width="250"
         WindowStyle="None" SizeToContent="Height"
         ShowInTaskbar="False"
-        ResizeMode="CanMinimize"
+        ResizeMode="NoResize"
         FlowDirection="{x:Static l:Localizer.FlowDirection}">
     <Window.Resources>
         <s:BoolToVisibilityConverter x:Key="NoNewVersionVisibility" TrueVisibility="Collapsed" FalseVisibility="Visible"/>

--- a/src/SyncTrayzor/Pages/AboutView.xaml
+++ b/src/SyncTrayzor/Pages/AboutView.xaml
@@ -6,6 +6,7 @@
         Height="400" Width="250"
         WindowStyle="None" SizeToContent="Height"
         ShowInTaskbar="False"
+        ResizeMode="CanMinimize"
         FlowDirection="{x:Static l:Localizer.FlowDirection}">
     <Window.Resources>
         <s:BoolToVisibilityConverter x:Key="NoNewVersionVisibility" TrueVisibility="Collapsed" FalseVisibility="Visible"/>

--- a/src/SyncTrayzor/Pages/AboutView.xaml
+++ b/src/SyncTrayzor/Pages/AboutView.xaml
@@ -65,7 +65,7 @@
                 <TextBlock Text="{l:Loc AboutView_ShowOtherLicenses}"/>
             </Hyperlink>
         </TextBlock>
-        <Button DockPanel.Dock="Bottom" Command="{s:Action Close}" IsDefault="True"
+        <Button DockPanel.Dock="Bottom" Command="{s:Action Close}" IsDefault="True" IsCancel="True"
                 HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,5,0,0"
                 Style="{StaticResource DialogButton}"
                 Content="{l:Loc Generic_Dialog_Close}"/>

--- a/src/SyncTrayzor/Pages/ConflictResolution/ConflictResolutionView.xaml
+++ b/src/SyncTrayzor/Pages/ConflictResolution/ConflictResolutionView.xaml
@@ -12,6 +12,7 @@
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance local:ConflictResolutionViewModel}"
         Title="{l:Loc ConflictResolutionView_Title}" Height="500" Width="800"
+        MinHeight="400" MinWidth="500"
         FlowDirection="{x:Static l:Localizer.FlowDirection}">
     <Window.Resources>
         <CollectionViewSource x:Key="ConflictsItemsSource" Source="{Binding Conflicts}">

--- a/src/SyncTrayzor/Pages/ConflictResolution/ConflictResolutionView.xaml
+++ b/src/SyncTrayzor/Pages/ConflictResolution/ConflictResolutionView.xaml
@@ -38,7 +38,9 @@
                 HorizontalAlignment="Right"
                 Command="{s:Action Close}"
                 Style="{StaticResource DialogButton}"
-                Content="{l:Loc Generic_Dialog_Close}"/>
+                Content="{l:Loc Generic_Dialog_Close}"
+                IsDefault="True"
+                IsCancel="True"/>
 
         <Border DockPanel.Dock="Bottom" Margin="0,10,0,0"
                 Style="{StaticResource SectionBorderStyle}"

--- a/src/SyncTrayzor/Pages/ConsoleView.xaml
+++ b/src/SyncTrayzor/Pages/ConsoleView.xaml
@@ -15,10 +15,10 @@
     <DockPanel>
         <DockPanel DockPanel.Dock="Top" LastChildFill="False" Height="27">
             <TextBlock DockPanel.Dock="Left" Margin="10,0,0,0" VerticalAlignment="Center" FontWeight="Bold" Text="{l:Loc ConsoleView_Title}"/>
-            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="50" Command="{s:Action ShowSettings}" Content="{l:Loc ConsoleView_SettingsButton}"/>
-            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="50" Command="{s:Action ClearLog}" Content="{l:Loc ConsoleView_ClearButton}"/>
-            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="50" Command="{s:Action PauseLog}" Content="{l:Loc ConsoleView_PauseButton}" Visibility="{Binding LogPaused, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}"/>
-            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="50" Command="{s:Action ResumeLog}" Content="{l:Loc ConsoleView_ResumeButton}" Visibility="{Binding LogPaused, Converter={x:Static s:BoolToVisibilityConverter.Instance}}"/>
+            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="75" Command="{s:Action ShowSettings}" Content="{l:Loc ConsoleView_SettingsButton}"/>
+            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="75" Command="{s:Action ClearLog}" Content="{l:Loc ConsoleView_ClearButton}"/>
+            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="75" Command="{s:Action PauseLog}" Content="{l:Loc ConsoleView_PauseButton}" Visibility="{Binding LogPaused, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}"/>
+            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="75" Command="{s:Action ResumeLog}" Content="{l:Loc ConsoleView_ResumeButton}" Visibility="{Binding LogPaused, Converter={x:Static s:BoolToVisibilityConverter.Instance}}"/>
         </DockPanel>
         <TextBox ScrollViewer.VerticalScrollBarVisibility="Auto"
                  ScrollViewer.HorizontalScrollBarVisibility="Auto"

--- a/src/SyncTrayzor/Pages/ConsoleView.xaml
+++ b/src/SyncTrayzor/Pages/ConsoleView.xaml
@@ -15,10 +15,10 @@
     <DockPanel>
         <DockPanel DockPanel.Dock="Top" LastChildFill="False" Height="27">
             <TextBlock DockPanel.Dock="Left" Margin="10,0,0,0" VerticalAlignment="Center" FontWeight="Bold" Text="{l:Loc ConsoleView_Title}"/>
-            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Command="{s:Action ShowSettings}" Content="{l:Loc ConsoleView_SettingsButton}"/>
-            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Command="{s:Action ClearLog}" Content="{l:Loc ConsoleView_ClearButton}"/>
-            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Command="{s:Action PauseLog}" Content="{l:Loc ConsoleView_PauseButton}" Visibility="{Binding LogPaused, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}"/>
-            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Command="{s:Action ResumeLog}" Content="{l:Loc ConsoleView_ResumeButton}" Visibility="{Binding LogPaused, Converter={x:Static s:BoolToVisibilityConverter.Instance}}"/>
+            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="50" Command="{s:Action ShowSettings}" Content="{l:Loc ConsoleView_SettingsButton}"/>
+            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="50" Command="{s:Action ClearLog}" Content="{l:Loc ConsoleView_ClearButton}"/>
+            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="50" Command="{s:Action PauseLog}" Content="{l:Loc ConsoleView_PauseButton}" Visibility="{Binding LogPaused, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}"/>
+            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="50" Command="{s:Action ResumeLog}" Content="{l:Loc ConsoleView_ResumeButton}" Visibility="{Binding LogPaused, Converter={x:Static s:BoolToVisibilityConverter.Instance}}"/>
         </DockPanel>
         <TextBox ScrollViewer.VerticalScrollBarVisibility="Auto"
                  ScrollViewer.HorizontalScrollBarVisibility="Auto"

--- a/src/SyncTrayzor/Pages/ConsoleView.xaml
+++ b/src/SyncTrayzor/Pages/ConsoleView.xaml
@@ -15,10 +15,10 @@
     <DockPanel>
         <DockPanel DockPanel.Dock="Top" LastChildFill="False" Height="27">
             <TextBlock DockPanel.Dock="Left" Margin="10,0,0,0" VerticalAlignment="Center" FontWeight="Bold" Text="{l:Loc ConsoleView_Title}"/>
-            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="75" Command="{s:Action ShowSettings}" Content="{l:Loc ConsoleView_SettingsButton}"/>
-            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="75" Command="{s:Action ClearLog}" Content="{l:Loc ConsoleView_ClearButton}"/>
-            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="75" Command="{s:Action PauseLog}" Content="{l:Loc ConsoleView_PauseButton}" Visibility="{Binding LogPaused, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}"/>
-            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" Width="75" Command="{s:Action ResumeLog}" Content="{l:Loc ConsoleView_ResumeButton}" Visibility="{Binding LogPaused, Converter={x:Static s:BoolToVisibilityConverter.Instance}}"/>
+            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" MinWidth="75" Command="{s:Action ShowSettings}" Content="{l:Loc ConsoleView_SettingsButton}"/>
+            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" MinWidth="75" Command="{s:Action ClearLog}" Content="{l:Loc ConsoleView_ClearButton}"/>
+            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" MinWidth="75" Command="{s:Action PauseLog}" Content="{l:Loc ConsoleView_PauseButton}" Visibility="{Binding LogPaused, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}"/>
+            <Button DockPanel.Dock="Right" Padding="3,0" Margin="0,3,5,3" Height="NaN" MinWidth="75" Command="{s:Action ResumeLog}" Content="{l:Loc ConsoleView_ResumeButton}" Visibility="{Binding LogPaused, Converter={x:Static s:BoolToVisibilityConverter.Instance}}"/>
         </DockPanel>
         <TextBox ScrollViewer.VerticalScrollBarVisibility="Auto"
                  ScrollViewer.HorizontalScrollBarVisibility="Auto"

--- a/src/SyncTrayzor/Pages/NewVersionAlertView.xaml
+++ b/src/SyncTrayzor/Pages/NewVersionAlertView.xaml
@@ -7,6 +7,7 @@
         Width="600" MaxHeight="600"
         Title="{l:Loc NewVersionAlertView_Title}"
         SizeToContent="Height"
+        MinHeight="250" MinWidth="500"
         FlowDirection="{x:Static l:Localizer.FlowDirection}">
     <DockPanel Margin="10">
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap">

--- a/src/SyncTrayzor/Pages/NewVersionAlertView.xaml
+++ b/src/SyncTrayzor/Pages/NewVersionAlertView.xaml
@@ -32,7 +32,7 @@
             <Button IsDefault="True" Command="{s:Action Download}" Content="{l:Loc NewVersionAlertView_Button_Download}"
                     Visibility="{Binding CanInstall, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}"/>
             <Button IsCancel="True" Command="{s:Action RemindLater}" Content="{l:Loc NewVersionAlertView_Button_RemindLater}"/>
-            <Button IsCancel="True" Command="{s:Action DontRemind}" Content="{l:Loc NewVersionAlertView_Button_DontRemind}"/>
+            <Button Command="{s:Action DontRemind}" Content="{l:Loc NewVersionAlertView_Button_DontRemind}"/>
         </StackPanel>
         <TextBlock DockPanel.Dock="Bottom" TextWrapping="Wrap" Margin="0,10,0,0" Text="{l:Loc NewVersionAlertView_DontRemindMeExplanation}"/>
 

--- a/src/SyncTrayzor/Pages/Settings/SettingsView.xaml
+++ b/src/SyncTrayzor/Pages/Settings/SettingsView.xaml
@@ -15,7 +15,6 @@
         MinWidth="430" MaxWidth="430"
         MinHeight="400" 
         SizeToContent="WidthAndHeight"
-        ResizeMode="CanMinimize"
         FlowDirection="{x:Static l:Localizer.FlowDirection}">
     <i:Interaction.Behaviors>
         <xaml:NoSizeBelowScreenBehaviour/>

--- a/src/SyncTrayzor/Pages/Settings/SettingsView.xaml
+++ b/src/SyncTrayzor/Pages/Settings/SettingsView.xaml
@@ -15,6 +15,7 @@
         MinWidth="430" MaxWidth="430"
         MinHeight="400" 
         SizeToContent="WidthAndHeight"
+        ResizeMode="CanMinimize"
         FlowDirection="{x:Static l:Localizer.FlowDirection}">
     <i:Interaction.Behaviors>
         <xaml:NoSizeBelowScreenBehaviour/>

--- a/src/SyncTrayzor/Pages/ShellView.xaml
+++ b/src/SyncTrayzor/Pages/ShellView.xaml
@@ -7,7 +7,7 @@
         xmlns:l="clr-namespace:SyncTrayzor.Localization"
         FlowDirection="{x:Static l:Localizer.FlowDirection}"
         Height="700" Width="1100"
-        MinHeight="300" MinWidth="300"
+        MinHeight="300" MinWidth="400"
         Title="SyncTrayzor">
     <i:Interaction.Behaviors>
         <xaml:WindowPlacementBehaviour Placement="{Binding Placement}"/>

--- a/src/SyncTrayzor/Pages/ShellView.xaml
+++ b/src/SyncTrayzor/Pages/ShellView.xaml
@@ -7,6 +7,7 @@
         xmlns:l="clr-namespace:SyncTrayzor.Localization"
         FlowDirection="{x:Static l:Localizer.FlowDirection}"
         Height="700" Width="1100"
+        MinHeight="300" MinWidth="300"
         Title="SyncTrayzor">
     <i:Interaction.Behaviors>
         <xaml:WindowPlacementBehaviour Placement="{Binding Placement}"/>

--- a/src/SyncTrayzor/Pages/ShellView.xaml
+++ b/src/SyncTrayzor/Pages/ShellView.xaml
@@ -31,18 +31,22 @@
             <MenuItem Header="{l:Loc ShellView_Menu_File}">
                 <MenuItem Header="{l:Loc ShellView_Menu_File_Settings}" Command="{s:Action ShowSettings}"/>
                 <MenuItem Header="{l:Loc ShellView_Menu_File_ConflictResolver}" Command="{s:Action ShowConflictResolver}"/>
+                <Separator/>
                 <MenuItem Header="{l:Loc ShellView_Menu_File_Exit}" Command="{s:Action Shutdown}"/>
             </MenuItem>
             <MenuItem Header="{l:Loc ShellView_Menu_Syncthing}">
                 <MenuItem Header="{l:Loc ShellView_Menu_Syncthing_Start}" Command="{s:Action Start}"/>
                 <MenuItem Header="{l:Loc ShellView_Menu_Syncthing_Stop}" Command="{s:Action Stop}"/>
                 <MenuItem Header="{l:Loc ShellView_Menu_Syncthing_Restart}" Command="{s:Action Restart}"/>
+                <Separator/>
                 <MenuItem Header="{l:Loc ShellView_Menu_Syncthing_Refresh}" InputGestureText="F5" Command="{s:Action RefreshBrowser}"/>
                 <MenuItem Header="{l:Loc ShellView_Menu_Syncthing_OpenExternal}" Command="{s:Action OpenBrowser}"/>
+                <Separator/>
                 <MenuItem Header="{l:Loc ShellView_Menu_Syncthing_KillAll}" Command="{s:Action KillAllSyncthingProcesses}"/>
             </MenuItem>
             <MenuItem Header="{l:Loc ShellView_Menu_View}">
                 <MenuItem Header="{l:Loc ShellView_Menu_View_SyncthingConsole}" IsCheckable="True" IsChecked="{Binding ShowConsole}"/>
+                <Separator/>
                 <MenuItem Header="{l:Loc ShellView_Menu_Zoom}" IsEnabled="{Binding CanZoomBrowser}">
                     <MenuItem Header="{l:Loc ShellView_Menu_Zoom_In}" InputGestureText="Ctrl++" Command="{s:Action BrowserZoomIn}"/>
                     <MenuItem Header="{l:Loc ShellView_Menu_Zoom_Out}" InputGestureText="Ctrl+-" Command="{s:Action BrowserZoomOut}"/>

--- a/src/SyncTrayzor/Pages/ShellViewModel.cs
+++ b/src/SyncTrayzor/Pages/ShellViewModel.cs
@@ -118,7 +118,7 @@ namespace SyncTrayzor.Pages
             if (this.windowManager.ShowMessageBox(
                     Resources.Dialog_ConfirmKillAllProcesses_Message,
                     Resources.Dialog_ConfirmKillAllProcesses_Title,
-                    MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                    MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
                 this.syncthingManager.KillAllSyncthingProcesses();
         }
 

--- a/src/SyncTrayzor/Pages/ThirdPartyComponentsView.xaml
+++ b/src/SyncTrayzor/Pages/ThirdPartyComponentsView.xaml
@@ -4,6 +4,7 @@
         xmlns:s="https://github.com/canton7/Stylet"
         xmlns:l="clr-namespace:SyncTrayzor.Localization"
         Title="{l:Loc ThirdPartyComponentsView_Title}" Height="700" Width="600"
+        MinHeight="500" MinWidth="400"
         FlowDirection="{x:Static l:Localizer.FlowDirection}">
     <DockPanel Margin="10">
         <TextBlock DockPanel.Dock="Top" Margin="0,10,0,10" TextWrapping="Wrap" Text="{l:Loc ThirdPartyComponentsView_Intro}"/>

--- a/src/SyncTrayzor/Pages/ThirdPartyComponentsView.xaml
+++ b/src/SyncTrayzor/Pages/ThirdPartyComponentsView.xaml
@@ -14,6 +14,7 @@
                 Margin="0,10,0,0"
                 Command="{s:Action RequestClose}"
                 IsDefault="True"
+                IsCancel="True"
                 Content="{l:Loc Generic_Dialog_Close}"
                 Style="{StaticResource DialogButton}"/>
 

--- a/src/SyncTrayzor/Pages/UnhandledExceptionView.xaml
+++ b/src/SyncTrayzor/Pages/UnhandledExceptionView.xaml
@@ -4,6 +4,7 @@
         xmlns:s="https://github.com/canton7/Stylet"
         xmlns:l="clr-namespace:SyncTrayzor.Localization"
         Height="400" Width="600"
+        MinHeight="300" MinWidth="400"
         Title="{l:Loc UnhandledExceptionView_Title}"
         FlowDirection="{x:Static l:Localizer.FlowDirection}">
     <DockPanel Margin="10">

--- a/src/SyncTrayzor/Pages/UnhandledExceptionView.xaml
+++ b/src/SyncTrayzor/Pages/UnhandledExceptionView.xaml
@@ -22,7 +22,8 @@
             <TextBlock Text="{l:Loc UnhandledExceptionView_PleaseOpenIssue_Post}"/>
         </TextBlock>
 
-        <Button DockPanel.Dock="Bottom" HorizontalAlignment="Right" Command="{s:Action Close}" Content="{l:Loc Generic_Dialog_Close}" Style="{StaticResource DialogButton}"/>
+        <Button DockPanel.Dock="Bottom" HorizontalAlignment="Right" Command="{s:Action Close}" Content="{l:Loc Generic_Dialog_Close}" Style="{StaticResource DialogButton}"
+                IsDefault="True" IsCancel="True"/>
         <TextBlock DockPanel.Dock="Bottom" Margin="0,10" TextWrapping="Wrap">
             <TextBlock Text="{l:Loc UnhandledExceptionView_LogFileLocation_Description}"/>
             <Hyperlink Command="{s:Action OpenLogFilePath}"><TextBlock Text="{l:Loc UnhandledExceptionView_LogFileLocation_Link}"/></Hyperlink>

--- a/src/SyncTrayzor/Properties/Resources.Designer.cs
+++ b/src/SyncTrayzor/Properties/Resources.Designer.cs
@@ -1879,7 +1879,7 @@ namespace SyncTrayzor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Close to Tray.
+        ///   Looks up a localized string similar to _Close to Tray.
         /// </summary>
         public static string TrayIcon_Menu_CloseToTray {
             get {

--- a/src/SyncTrayzor/Properties/Resources.Designer.cs
+++ b/src/SyncTrayzor/Properties/Resources.Designer.cs
@@ -1536,7 +1536,7 @@ namespace SyncTrayzor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Syncthing Console.
+        ///   Looks up a localized string similar to Syncthing _Console.
         /// </summary>
         public static string ShellView_Menu_View_SyncthingConsole {
             get {

--- a/src/SyncTrayzor/Properties/Resources.resx
+++ b/src/SyncTrayzor/Properties/Resources.resx
@@ -375,7 +375,7 @@ Details on each component, and its license text, are shown below.</value>
     <value>Finished Syncing</value>
   </data>
   <data name="TrayIcon_Menu_CloseToTray" xml:space="preserve">
-    <value>Close to Tray</value>
+    <value>_Close to Tray</value>
     <comment>Menu option available when right-clicking the tray icon. Instructs SyncTrayzor to minimize itself to the tray</comment>
   </data>
   <data name="TrayIcon_Menu_Exit" xml:space="preserve">

--- a/src/SyncTrayzor/Properties/Resources.resx
+++ b/src/SyncTrayzor/Properties/Resources.resx
@@ -506,7 +506,7 @@ SyncTrayzor is going to have to close. Sorry about that</value>
     <value>_View</value>
   </data>
   <data name="ShellView_Menu_View_SyncthingConsole" xml:space="preserve">
-    <value>Syncthing Console</value>
+    <value>Syncthing _Console</value>
   </data>
   <data name="NewVersionAlertView_Button_Install" xml:space="preserve">
     <value>Install Now</value>


### PR DESCRIPTION
Shell:
 - Added menu separators
 - Added access key for "Syncthing Console" menu item
 - Added minimum width and height
 - Increased size of console buttons and make them consistent

Tray icon:
 - Added menu separators
 - Added access key for "Close to Tray" menu item
 - Added tooltip

About window:
 - Added close on escape hotkey
 - Disabled resize

Settings window:
 - Disabled resize

Conflict Resolver window:
 - Added close on enter and escape hotkeys
 - Added minimum width and height

Other:
- Change "Kill all Syncthing processes" message box image from question to warning (https://msdn.microsoft.com/en-us/library/windows/desktop/dn742473(v=vs.85).aspx)