### PR TITLE
Chocolatey package include license and verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ deploy
 *.pvk
 /src/SyncTrayzor/Icons/*.png
 security/private_key.asc
+chocolatey/tools/LICENSE.txt

--- a/Rakefile
+++ b/Rakefile
@@ -253,6 +253,7 @@ desc 'Build chocolatey package'
 task :chocolatey do
   chocolatey_dir = File.dirname(CHOCOLATEY_NUSPEC)
   cp Dir[File.join(DEPLOY_DIR, 'SyncTrayzorSetup-*.exe')], File.join(chocolatey_dir, 'tools')
+  cp 'LICENSE.txt', File.join(chocolatey_dir, 'tools')
   Dir.chdir(chocolatey_dir) do
     sh "choco pack"
   end

--- a/chocolatey/tools/VERIFICATION.txt
+++ b/chocolatey/tools/VERIFICATION.txt
@@ -1,0 +1,7 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+This package is published by the developer of SyncTrayzor. 
+Binaries are identical to the setup binaries available at the GitHub release page:
+https://github.com/canton7/SyncTrayzor/releases


### PR DESCRIPTION
I forgot in #550 to add the `VERIFICATION.txt` and `LICENSE.txt` files, sorry about that. 

That is why the 1.1.25 package failed validation on chocolatey.org. 

Feel free to adjust the wording in the verification file.

For more information on why these are required see:
https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0005
https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0006
 