### PR TITLE
Chocolatey depend on dotnetfx and add skipdotnet to installer

### DIFF
--- a/chocolatey/synctrayzor.nuspec
+++ b/chocolatey/synctrayzor.nuspec
@@ -44,6 +44,8 @@ Features include:
     <dependencies>
       <!-- Chocolatey 0.9.9 required in order to access the chocolateyPackageName and chocolateyPackageVersion environment variables -->
       <dependency id="chocolatey" version="0.9.9" />
+      <!-- Make sure that .Net 4.7.2 or better is installed -->
+      <dependency id="dotnetfx" version="4.7.2" />
     </dependencies>
     <releaseNotes>https://github.com/canton7/SyncTrayzor/blob/master/CHANGELOG.md</releaseNotes>
     <!--<provides></provides>-->

--- a/chocolatey/tools/chocolateyinstall.ps1
+++ b/chocolatey/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ $toolsDir              = "$(Split-Path -parent $MyInvocation.MyCommand.Definitio
 $packageName= 'SyncTrayzor'
 $file       = (Join-Path $toolsDir 'SyncTrayzorSetup-x86.exe')
 $file64     = (Join-Path $toolsDir 'SyncTrayzorSetup-x64.exe')
-$silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /SKIPDOTNET'
+$silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /SkipDotNetInstall'
 $fileType   = 'exe'
 $validExitCodes = @(0)
 

--- a/chocolatey/tools/chocolateyinstall.ps1
+++ b/chocolatey/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ $toolsDir              = "$(Split-Path -parent $MyInvocation.MyCommand.Definitio
 $packageName= 'SyncTrayzor'
 $file       = (Join-Path $toolsDir 'SyncTrayzorSetup-x86.exe')
 $file64     = (Join-Path $toolsDir 'SyncTrayzorSetup-x64.exe')
-$silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
+$silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /SKIPDOTNET'
 $fileType   = 'exe'
 $validExitCodes = @(0)
 

--- a/installer/common.iss
+++ b/installer/common.iss
@@ -250,13 +250,31 @@ begin
   end
 end;
 
+function CmdLineParamNotExists(const Value: string): Boolean;
+var
+  I: Integer;  
+begin
+  Result := True;
+  for I := 1 to ParamCount do
+    if CompareText(ParamStr(I), Value) = 0 then
+    begin
+      Result := False;
+      Exit;
+    end;
+end;
+
+function NoSkipDotNet(): Boolean;
+begin
+  Result := CmdLineParamNotExists('/SKIPDOTNET');
+end;
+
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 begin
   // 'NeedsRestart' only has an effect if we return a non-empty string, thus aborting the installation.
   // If the installers indicate that they want a restart, this should be done at the end of installation.
   // Therefore we set the global 'restartRequired' if a restart is needed, and return this from NeedRestart()
 
-  if DotNetIsMissing() then
+  if DotNetIsMissing() And NoSkipDotNet() then
   begin
     Result := InstallDotNet();
   end;

--- a/installer/common.iss
+++ b/installer/common.iss
@@ -250,22 +250,18 @@ begin
   end
 end;
 
-function CmdLineParamNotExists(const Value: string): Boolean;
+function CmdLineParamGiven(const Value: String): Boolean;
 var
   I: Integer;  
 begin
-  Result := True;
+  // Can't use {param}, as it doesn't match flags with no value
+  Result := False;
   for I := 1 to ParamCount do
     if CompareText(ParamStr(I), Value) = 0 then
     begin
-      Result := False;
+      Result := True;
       Exit;
     end;
-end;
-
-function NoSkipDotNet(): Boolean;
-begin
-  Result := CmdLineParamNotExists('/SKIPDOTNET');
 end;
 
 function PrepareToInstall(var NeedsRestart: Boolean): String;
@@ -274,7 +270,7 @@ begin
   // If the installers indicate that they want a restart, this should be done at the end of installation.
   // Therefore we set the global 'restartRequired' if a restart is needed, and return this from NeedRestart()
 
-  if DotNetIsMissing() And NoSkipDotNet() then
+  if not CmdLineParamGiven('/SkipDotNetInstall') and DotNetIsMissing() then
   begin
     Result := InstallDotNet();
   end;
@@ -286,19 +282,8 @@ begin
 end;
 
 function ShouldStartSyncTrayzor(): Boolean;
-var
-  flagPassed: Boolean;
-  i: Integer;
 begin
-  // Can't use {param}, as it doesn't match flags with no value
-  flagPassed := False;
-  for i := 0 to ParamCount do begin
-    if ParamStr(i) = '/StartSyncTrayzor' then begin
-      flagPassed := True;
-      break;
-    end;
-  end;
-  Result := (not WizardSilent()) or flagPassed;
+  Result := (not WizardSilent()) or CmdLineParamGiven('/StartSyncTrayzor');
 end;
 
 function SyncTrayzorStartFlags(param: String): String;


### PR DESCRIPTION
Fixes: #614 

Could use another sanity check. 

I tested the package in the [chocolatey test environment](https://github.com/chocolatey-community/chocolatey-test-environment).