### PR TITLE
Add legacy mode option to fix tooltip positioning issues (#398 and #760)

### DIFF
--- a/src/SyncTrayzor/App.config
+++ b/src/SyncTrayzor/App.config
@@ -34,6 +34,7 @@
       </PathConfiguration>
       <DefaultUserConfiguration Version="10">
         <ShowTrayIconOnlyOnClose>false</ShowTrayIconOnlyOnClose>
+        <ShowTrayToolTipInLegacyMode>false</ShowTrayToolTipInLegacyMode>
         <MinimizeToTray>false</MinimizeToTray>
         <CloseToTray>true</CloseToTray>
         <ShowDeviceConnectivityBalloons>false</ShowDeviceConnectivityBalloons>

--- a/src/SyncTrayzor/NotifyIcon/NotifyIconManager.cs
+++ b/src/SyncTrayzor/NotifyIcon/NotifyIconManager.cs
@@ -20,6 +20,7 @@ namespace SyncTrayzor.NotifyIcon
     public interface INotifyIconManager : IDisposable
     {
         bool ShowOnlyOnClose { get; set; }
+        bool ShowInLegacyMode { get; set; }
         bool MinimizeToTray { get; set; }
         bool CloseToTray { get; set; }
         Dictionary<string, bool> FolderNotificationsEnabled { get; set; }
@@ -56,6 +57,17 @@ namespace SyncTrayzor.NotifyIcon
             {
                 this._showOnlyOnClose = value;
                 this.viewModel.Visible = !this._showOnlyOnClose || this.applicationWindowState.ScreenState == ScreenState.Closed;
+            }
+        }
+
+        private bool _showInLegacyMode;
+        public bool ShowInLegacyMode
+        {
+            get => this._showInLegacyMode;
+            set
+            {
+                this._showInLegacyMode = value;
+                Utils.TrayToolTipWorkaround.SetLegacyMode(value, this.taskbarIcon);
             }
         }
 

--- a/src/SyncTrayzor/Pages/Settings/SettingsView.xaml
+++ b/src/SyncTrayzor/Pages/Settings/SettingsView.xaml
@@ -75,6 +75,7 @@
                                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding ShowDeviceConnectivityBalloons.Value}" Content="{l:Loc SettingsView_ShowDeviceConnectivityBalloons}"/>
                                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding ShowDeviceOrFolderRejectedBalloons.Value}" Content="{l:Loc SettingsView_ShowDeviceOrFolderRejectedBalloons}"/>
                                 <CheckBox DockPanel.Dock="Top" IsChecked="{Binding ShowTrayIconOnlyOnClose.Value}" Content="{l:Loc SettingsView_OnlyShowTrayIconOnClose}"/>
+                                <CheckBox DockPanel.Dock="Top" IsChecked="{Binding ShowTrayToolTipInLegacyMode.Value}" Content="{l:Loc SettingsView_ShowTrayToolTipInLegacyMode}"/>
                                 <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,5,0,0">
                                     <Label Padding="0,0,5,0" Target="{Binding ElementName=IconAnimationModeSelect}" VerticalAlignment="Center" Content="{l:Loc SettingsView_AnimateTrayIcon}"/>
                                     <ComboBox x:Name="IconAnimationModeSelect" ItemsSource="{Binding IconAnimationModes}" SelectedValuePath="Value" SelectedValue="{Binding IconAnimationMode.Value}"/>

--- a/src/SyncTrayzor/Pages/Settings/SettingsViewModel.cs
+++ b/src/SyncTrayzor/Pages/Settings/SettingsViewModel.cs
@@ -67,6 +67,8 @@ namespace SyncTrayzor.Pages.Settings
         public SettingItem<bool> PauseDevicesOnMeteredNetworks { get; }
 
         public SettingItem<bool> ShowTrayIconOnlyOnClose { get; }
+
+        public SettingItem<bool> ShowTrayToolTipInLegacyMode { get; }
         public SettingItem<bool> ShowSynchronizedBalloonEvenIfNothingDownloaded { get; }
         public SettingItem<bool> ShowDeviceConnectivityBalloons { get; }
         public SettingItem<bool> ShowDeviceOrFolderRejectedBalloons { get; }
@@ -138,6 +140,7 @@ namespace SyncTrayzor.Pages.Settings
             this.PauseDevicesOnMeteredNetworksSupported = meteredNetworkManager.IsSupportedByWindows;
 
             this.ShowTrayIconOnlyOnClose = this.CreateBasicSettingItem(x => x.ShowTrayIconOnlyOnClose);
+            this.ShowTrayToolTipInLegacyMode = this.CreateBasicSettingItem(x => x.ShowTrayToolTipInLegacyMode);
             this.ShowSynchronizedBalloonEvenIfNothingDownloaded = this.CreateBasicSettingItem(x => x.ShowSynchronizedBalloonEvenIfNothingDownloaded);
             this.ShowDeviceConnectivityBalloons = this.CreateBasicSettingItem(x => x.ShowDeviceConnectivityBalloons);
             this.ShowDeviceOrFolderRejectedBalloons = this.CreateBasicSettingItem(x => x.ShowDeviceOrFolderRejectedBalloons);

--- a/src/SyncTrayzor/Properties/Resources.Designer.cs
+++ b/src/SyncTrayzor/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace SyncTrayzor.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -554,7 +554,7 @@ namespace SyncTrayzor.Properties {
         ///
         ///Please read the log to determine the cause.
         ///
-        ///If &quot;FATAL: Cannot open database&quot; appears, please close any other open instances of Syncthing. If SyncTrayzor crashed previously, there may still be zombine Syncthing processes alive. Please use the menu option &quot;Syncthing -&gt; Kill all Syncthing processes&quot; to stop them, then use &quot;Syncthing -&gt; Start&quot; to start Syncthing again..
+        ///If &quot;FATAL: Cannot open database&quot; appears, please close any other open instances of Syncthing. If SyncTrayzor crashed previously, there may still be zombie Syncthing processes alive. Please use the menu option &quot;Syncthing -&gt; Kill all Syncthing processes&quot; to stop them, then use &quot;Syncthing -&gt; Start&quot; to start Syncthing again..
         /// </summary>
         public static string Dialog_FailedToStartSyncthing_Message {
             get {
@@ -1207,6 +1207,15 @@ namespace SyncTrayzor.Properties {
         public static string SettingsView_ShowSynchronizedBalloonIfNoFilesTransferred {
             get {
                 return ResourceManager.GetString("SettingsView_ShowSynchronizedBalloonIfNoFilesTransferred", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show TrayToolTip in legacy mode (Experimental): Check this option if the TrayToolTip is displaying in the wrong location to attempt to fix it..
+        /// </summary>
+        public static string SettingsView_ShowTrayToolTipInLegacyMode {
+            get {
+                return ResourceManager.GetString("SettingsView_ShowTrayToolTipInLegacyMode", resourceCulture);
             }
         }
         

--- a/src/SyncTrayzor/Properties/Resources.resx
+++ b/src/SyncTrayzor/Properties/Resources.resx
@@ -1002,4 +1002,7 @@ Please donate to my charity fundraising campaign.</value>
   <data name="BarAlertsView_IntelXeGraphics_DismissLink" xml:space="preserve">
     <value>Dismiss</value>
   </data>
+  <data name="SettingsView_ShowTrayToolTipInLegacyMode" xml:space="preserve">
+    <value>Show TrayToolTip in legacy mode (Experimental): Check this option if the TrayToolTip is displaying in the wrong location to attempt to fix it.</value>
+  </data>
 </root>

--- a/src/SyncTrayzor/Services/Config/Configuration.cs
+++ b/src/SyncTrayzor/Services/Config/Configuration.cs
@@ -24,6 +24,7 @@ namespace SyncTrayzor.Services.Config
         }
 
         public bool ShowTrayIconOnlyOnClose { get; set; }
+        public bool ShowTrayToolTipInLegacyMode { get; set; }
         public bool MinimizeToTray { get; set; }
         public bool CloseToTray { get; set; }
         public bool ShowDeviceConnectivityBalloons { get; set; }
@@ -78,6 +79,7 @@ namespace SyncTrayzor.Services.Config
             // Default configuration is for a portable setup.
 
             this.ShowTrayIconOnlyOnClose = false;
+            this.ShowTrayToolTipInLegacyMode = false;
             this.MinimizeToTray = false;
             this.CloseToTray = true;
             this.ShowSynchronizedBalloonEvenIfNothingDownloaded = false;
@@ -116,6 +118,7 @@ namespace SyncTrayzor.Services.Config
         public Configuration(Configuration other)
         {
             this.ShowTrayIconOnlyOnClose = other.ShowTrayIconOnlyOnClose;
+            this.ShowTrayToolTipInLegacyMode = other.ShowTrayToolTipInLegacyMode;
             this.MinimizeToTray = other.MinimizeToTray;
             this.CloseToTray = other.CloseToTray;
             this.ShowSynchronizedBalloonEvenIfNothingDownloaded = other.ShowSynchronizedBalloonEvenIfNothingDownloaded;
@@ -153,7 +156,7 @@ namespace SyncTrayzor.Services.Config
 
         public override string ToString()
         {
-            return $"<Configuration ShowTrayIconOnlyOnClose={this.ShowTrayIconOnlyOnClose} MinimizeToTray={this.MinimizeToTray} CloseToTray={this.CloseToTray} " +
+            return $"<Configuration ShowTrayIconOnlyOnClose={this.ShowTrayIconOnlyOnClose} ShowTrayToolTipInLegacyMode={this.ShowTrayToolTipInLegacyMode} MinimizeToTray={this.MinimizeToTray} CloseToTray={this.CloseToTray} " +
                 $"ShowDeviceConnectivityBalloons={this.ShowDeviceConnectivityBalloons} ShowDeviceOrFolderRejectedBalloons={this.ShowDeviceOrFolderRejectedBalloons} " +
                 $"SyncthingAddress={this.SyncthingAddress} StartSyncthingAutomatically={this.StartSyncthingAutomatically} " +
                 $"SyncthingCommandLineFlags=[{String.Join(",", this.SyncthingCommandLineFlags)}] " +

--- a/src/SyncTrayzor/Services/ConfigurationApplicator.cs
+++ b/src/SyncTrayzor/Services/ConfigurationApplicator.cs
@@ -86,6 +86,7 @@ namespace SyncTrayzor.Services
             this.notifyIconManager.MinimizeToTray = configuration.MinimizeToTray;
             this.notifyIconManager.CloseToTray = configuration.CloseToTray;
             this.notifyIconManager.ShowOnlyOnClose = configuration.ShowTrayIconOnlyOnClose;
+            this.notifyIconManager.ShowInLegacyMode = configuration.ShowTrayToolTipInLegacyMode;
             this.notifyIconManager.FolderNotificationsEnabled = configuration.Folders.ToDictionary(x => x.ID, x => x.NotificationsEnabled);
             this.notifyIconManager.ShowSynchronizedBalloonEvenIfNothingDownloaded = configuration.ShowSynchronizedBalloonEvenIfNothingDownloaded;
             this.notifyIconManager.ShowDeviceConnectivityBalloons = configuration.ShowDeviceConnectivityBalloons;

--- a/src/SyncTrayzor/SyncTrayzor.csproj
+++ b/src/SyncTrayzor/SyncTrayzor.csproj
@@ -15,6 +15,9 @@
     <WarningLevel>4</WarningLevel>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <TargetFrameworkProfile />
+    <GenerateResourceMSBuildArchitecture>CurrentArchitecture</GenerateResourceMSBuildArchitecture>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -27,11 +30,8 @@
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile />
-    <GenerateResourceMSBuildArchitecture>CurrentArchitecture</GenerateResourceMSBuildArchitecture>
   </PropertyGroup>
   <PropertyGroup>
   </PropertyGroup>
@@ -339,6 +339,7 @@
     <Compile Include="Utils\StringExtensions.cs" />
     <Compile Include="Utils\SynchronizedEventDispatcher.cs" />
     <Compile Include="Design\ViewModelLocator.cs" />
+    <Compile Include="Utils\TrayToolTipWorkaround.cs" />
     <Compile Include="Xaml\ActivateBehaviour.cs" />
     <Compile Include="Xaml\CultureAwareBinding.cs" />
     <Compile Include="Xaml\GridLengthToAbsoluteConverter.cs" />

--- a/src/SyncTrayzor/Utils/TrayToolTipWorkaround.cs
+++ b/src/SyncTrayzor/Utils/TrayToolTipWorkaround.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Windows;
+using System.Reflection;
+using Hardcodet.Wpf.TaskbarNotification;
+using Hardcodet.Wpf.TaskbarNotification.Interop;
+
+namespace SyncTrayzor.Utils
+{
+    public static class TrayToolTipWorkaround {
+        private static bool hasFixed = false;
+        private static bool legacyMode = false;
+
+        private static void setTipTextMode(TaskbarIcon taskbarIcon) {
+            if (!hasFixed || taskbarIcon == null) {
+                return;
+            }
+
+            if (taskbarIcon.TrayToolTip == null && taskbarIcon.TrayToolTipResolved != null) {
+                // icon data
+                FieldInfo iconDataField = typeof(TaskbarIcon).GetField("iconData", BindingFlags.NonPublic | BindingFlags.Instance);
+                if (iconDataField == null) {
+                    return;
+                }
+
+                NotifyIconData iconData = (NotifyIconData) iconDataField.GetValue(taskbarIcon);
+                IconDataMembers flags = IconDataMembers.Tip;
+                if (legacyMode) {
+                    flags |= IconDataMembers.UseLegacyToolTips;
+                }
+                if (iconData.ValidMembers != flags) {
+                    iconData.ValidMembers = flags;
+
+                    // get util type
+                    Type utilType = typeof(TaskbarIcon).GetTypeInfo().Assembly.GetType("Hardcodet.Wpf.TaskbarNotification.Util");
+                    if (utilType == null)
+                    {
+                        return;
+                    }
+
+                    // get write method
+                    MethodInfo writeIconDataMethod = utilType.GetMethod("WriteIconData", new Type[] { typeof(NotifyIconData).MakeByRefType(), typeof(NotifyCommand) });
+                    if (writeIconDataMethod == null)
+                    {
+                        return;
+                    }
+
+                    writeIconDataMethod.Invoke(null, new object[] { iconData, NotifyCommand.Modify });
+                }
+            }
+        }
+
+        private static void doFix(TaskbarIcon taskbarIcon) {
+            // register new DependencyProperty
+            DependencyProperty newProperty = DependencyProperty.Register("NewToolTipText", typeof(string), typeof(TaskbarIcon),
+                new FrameworkPropertyMetadata(string.Empty, (d, e) => {
+                    // call the origin callback func
+                    MethodInfo originCbMethod = typeof(TaskbarIcon).GetMethod("ToolTipTextPropertyChanged", BindingFlags.Static | BindingFlags.NonPublic);
+                    originCbMethod?.Invoke(null, new object[] { d, e });
+
+                    // try to refresh legacy mode
+                    TaskbarIcon t = d as TaskbarIcon;
+                    setTipTextMode(t);
+                })
+            );
+
+            // back up tip text
+            string tipTextBackup = string.Empty;
+            if (taskbarIcon != null && !string.IsNullOrEmpty(taskbarIcon.ToolTipText)) { 
+                tipTextBackup = taskbarIcon.ToolTipText;
+            }
+
+            // set new ToolTipTextProperty, every time update ToolTipText, will run own func
+            var propertyFieldInfo = typeof(TaskbarIcon).GetField("ToolTipTextProperty", BindingFlags.Static | BindingFlags.Public);
+            propertyFieldInfo.SetValue(null, newProperty);
+
+            // set tip text
+            if (taskbarIcon != null) {
+                taskbarIcon.ToolTipText  = tipTextBackup;
+            }
+        }
+
+		public static void SetLegacyMode(bool _legacyMode, TaskbarIcon taskbarIcon)
+        {
+            if(_legacyMode && !hasFixed) { 
+                doFix(taskbarIcon);
+                hasFixed = true;
+            }
+            legacyMode = _legacyMode;
+            setTipTextMode(taskbarIcon);
+        }
+    }
+}


### PR DESCRIPTION
We have observed longstanding issues with tooltip positioning since 2017. Unfortunately a direct fix was not immediately feasible due to upstream dependencies.

This PR humbly proposes a "Show Tooltip in Legacy Mode" option as a workaround to issues #398 and #760. The goal is to use a different method to help address the positioning problems temporarily.

Extensive testing suggests this workaround is reliable without new bugs. While not a permanent solution, it may help alleviate the problem without significant changes for now.

The option remains experimental by nature. We hope to identify a better approach once dependencies allow. Any feedback would be appreciated to progress this effort.

Approval of this proposed change would be greatly valued in resolving a long-troubling user experience issue. We thank you for your consideration and understanding.